### PR TITLE
Fix bug: Logout route isn't triggered

### DIFF
--- a/app/config/routes.js
+++ b/app/config/routes.js
@@ -13,8 +13,8 @@ export default function getRoutes (checkAuth) {
           <Route path='/login' component={checkAuth(AuthenticateContainer)} />
           <Route path='/feed' component={checkAuth(FeedContainer)} />
           <Route path='/duck-detail/:duckId' component={checkAuth(DuckDetailsContainer)}/>
-          <Route path='/:uid' component={checkAuth(UserContainer)}/>
           <Route path='/logout' component={LogoutContainer} />
+          <Route path='/:uid' component={checkAuth(UserContainer)}/>
         </Switch>
       </MainContainer>
     </Router>


### PR DESCRIPTION
Closes #1 

#### Type of change
Small bug fix

#### Description
Placed the ___/logout___ route above of the ___/:uid___ route so the Router can match when a user is trying to logout from the application and call the correct component